### PR TITLE
Add 216j to compatibility list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ DS213j    armada370  *N/A*       No (Kernel version too old)
 DS214play armada370  *N/A*       No (Kernel version too old)
 DS214se   armada370  *N/A*       No (Kernel version too old)
 DS216se   armada370  *N/A*       No (Kernel version too old)
+DS216j    armada38x  6.2         Yes
 DS218+    apollolake 6.2         Yes
 DS218j    armada38x  6.2         Yes
 DS414slim armada370  *N/A*       No (Kernel version too old)


### PR DESCRIPTION
Here's the info I got:
```
adrien@DS216j:/$ uname -a
Linux DS216j 3.10.105 #24922 SMP Fri May 10 02:48:35 CST 2019 armv7l GNU/Linux synology_armada38x_ds216j
adrien@DS216j:/$ cat /proc/cpuinfo
processor	: 0
model name	: ARMv7 Processor rev 1 (v7l)
BogoMIPS	: 2131.55
Features	: swp half thumb fastmult vfp edsp neon vfpv3 tls 
CPU implementer	: 0x41
CPU architecture: 7
CPU variant	: 0x4
CPU part	: 0xc09
CPU revision	: 1

processor	: 1
model name	: ARMv7 Processor rev 1 (v7l)
BogoMIPS	: 2125.00
Features	: swp half thumb fastmult vfp edsp neon vfpv3 tls 
CPU implementer	: 0x41
CPU architecture: 7
CPU variant	: 0x4
CPU part	: 0xc09
CPU revision	: 1

Hardware	: Marvell Armada 380/381/382/383/384/385/388 (Device Tree)
Revision	: 0000
Serial		: 0000000000000000
```