### PR TITLE
Add DS1618+ to compatibility list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,7 @@ Model     Platform   DSM Version Is working?
 DS1019+   apollolake 6.2         Yes
 DS114     armada370  *N/A*       No (Kernel version too old)
 DS115j    armada370  *N/A*       No (Kernel version too old)
+DS1618+   denverton  6.2         Yes
 DS1817+   avoton     6.2         Yes
 DS213j    armada370  *N/A*       No (Kernel version too old)
 DS213j    armada370  *N/A*       No (Kernel version too old)


### PR DESCRIPTION
Hi,
I've successfully managed to route traffic over my Synology, including accessibility and use of the Internet connection. 

also note
https://github.com/runfalk/synology-wireguard/issues/10#issuecomment-522230356

```
ash-4.3# uname -a
Linux Kuermel_Server 4.4.59+ #24922 SMP PREEMPT Wed Jul 3 16:36:40 CST 2019 x86_64 GNU/Linux synology_denverton_1618+
ash-4.3# cat /proc/cpuinfo
processor       : 0
vendor_id       : GenuineIntel
cpu family      : 6
model           : 95
model name      : Intel(R) Atom(TM) CPU C3538 @ 2.10GHz
stepping        : 1
microcode       : 0x24
cpu MHz         : 2100.000
cache size      : 2048 KB
physical id     : 0
siblings        : 4
core id         : 2
cpu cores       : 4
apicid          : 4
initial apicid  : 4
fpu             : yes
fpu_exception   : yes
cpuid level     : 21
wp              : yes
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg cx16 xtpr pdcm sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave rdrand lahf_lm 3dnowprefetch epb intel_pt ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust smep erms mpx rdseed smap clflushopt sha_ni xsaveopt xsavec xgetbv1 dtherm arat pln pts arch_capabilities
bugs            : spectre_v1 spectre_v2 spec_store_bypass
bogomips        : 4199.97
clflush size    : 64
cache_alignment : 64
address sizes   : 39 bits physical, 48 bits virtual
power management:

processor       : 1
vendor_id       : GenuineIntel
cpu family      : 6
model           : 95
model name      : Intel(R) Atom(TM) CPU C3538 @ 2.10GHz
stepping        : 1
microcode       : 0x24
cpu MHz         : 2100.000
cache size      : 2048 KB
physical id     : 0
siblings        : 4
core id         : 6
cpu cores       : 4
apicid          : 12
initial apicid  : 12
fpu             : yes
fpu_exception   : yes
cpuid level     : 21
wp              : yes
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg cx16 xtpr pdcm sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave rdrand lahf_lm 3dnowprefetch epb intel_pt ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust smep erms mpx rdseed smap clflushopt sha_ni xsaveopt xsavec xgetbv1 dtherm arat pln pts arch_capabilities
bugs            : spectre_v1 spectre_v2 spec_store_bypass
bogomips        : 4199.97
clflush size    : 64
cache_alignment : 64
address sizes   : 39 bits physical, 48 bits virtual
power management:

processor       : 2
vendor_id       : GenuineIntel
cpu family      : 6
model           : 95
model name      : Intel(R) Atom(TM) CPU C3538 @ 2.10GHz
stepping        : 1
microcode       : 0x24
cpu MHz         : 2100.000
cache size      : 2048 KB
physical id     : 0
siblings        : 4
core id         : 8
cpu cores       : 4
apicid          : 16
initial apicid  : 16
fpu             : yes
fpu_exception   : yes
cpuid level     : 21
wp              : yes
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg cx16 xtpr pdcm sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave rdrand lahf_lm 3dnowprefetch epb intel_pt ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust smep erms mpx rdseed smap clflushopt sha_ni xsaveopt xsavec xgetbv1 dtherm arat pln pts arch_capabilities
bugs            : spectre_v1 spectre_v2 spec_store_bypass
bogomips        : 4199.97
clflush size    : 64
cache_alignment : 64
address sizes   : 39 bits physical, 48 bits virtual
power management:

processor       : 3
vendor_id       : GenuineIntel
cpu family      : 6
model           : 95
model name      : Intel(R) Atom(TM) CPU C3538 @ 2.10GHz
stepping        : 1
microcode       : 0x24
cpu MHz         : 2100.000
cache size      : 2048 KB
physical id     : 0
siblings        : 4
core id         : 12
cpu cores       : 4
apicid          : 24
initial apicid  : 24
fpu             : yes
fpu_exception   : yes
cpuid level     : 21
wp              : yes
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg cx16 xtpr pdcm sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave rdrand lahf_lm 3dnowprefetch epb intel_pt ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust smep erms mpx rdseed smap clflushopt sha_ni xsaveopt xsavec xgetbv1 dtherm arat pln pts arch_capabilities
bugs            : spectre_v1 spectre_v2 spec_store_bypass
bogomips        : 4199.97
clflush size    : 64
cache_alignment : 64
address sizes   : 39 bits physical, 48 bits virtual
power management:
```
