### PR TITLE
Add 716+II to compatibility list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,7 @@ DS218j    armada38x  6.2         Yes
 DS414slim armada370  *N/A*       No (Kernel version too old)
 DS415+    avoton     6.2         Yes
 DS713+    cedarview  6.2         Yes
+DS716+II  braswell   6.2         Yes
 DS918+    apollolake 6.2         Yes
 RS214     armada370  *N/A*       No (Kernel version too old)
 RS816     armada38x  6.2         Yes


### PR DESCRIPTION
Here's the info I got:

```bash
#  uname -a
Linux SynHome 3.10.105 #24922 SMP Wed Jul 3 16:34:56 CST 2019 x86_64 GNU/Linux synology_braswell_716+II

# cat /proc/cpuinfo

processor       : 2
vendor_id       : GenuineIntel
cpu family      : 6
model           : 76
model name      : Intel(R) Celeron(R) CPU  N3160  @ 1.60GHz
stepping        : 4
microcode       : 0x404
cpu MHz         : 1601.000
cache size      : 1024 KB
physical id     : 0
siblings        : 4
core id         : 2
cpu cores       : 4
apicid          : 4
initial apicid  : 4
fpu             : yes
fpu_exception   : yes
cpuid level     : 11
wp              : yes
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 cx16 xtpr pdcm sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes rdrand lahf_lm 3dnowprefetch ida arat epb invpcid_single tpr_shadow vnmi flexpriority ept vpid tsc_adjust smep erms
bogomips        : 3199.74
clflush size    : 64
cache_alignment : 64
address sizes   : 36 bits physical, 48 bits virtual
power management:

processor       : 3
vendor_id       : GenuineIntel
cpu family      : 6
model           : 76
model name      : Intel(R) Celeron(R) CPU  N3160  @ 1.60GHz
stepping        : 4
microcode       : 0x404
cpu MHz         : 1601.000
cache size      : 1024 KB
physical id     : 0
siblings        : 4
core id         : 3
cpu cores       : 4
apicid          : 6
initial apicid  : 6
fpu             : yes
fpu_exception   : yes
cpuid level     : 11
wp              : yes
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 cx16 xtpr pdcm sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes rdrand lahf_lm 3dnowprefetch ida arat epb invpcid_single tpr_shadow vnmi flexpriority ept vpid tsc_adjust smep erms
bogomips        : 3199.74
clflush size    : 64
cache_alignment : 64
address sizes   : 36 bits physical, 48 bits virtual
power management:

# wg
interface: wg0
  public key: (hidden)
  private key: (hidden)
  listening port: 51820

peer: (hidden)
  endpoint: example.com:21841
  allowed ips: 192.168.2.2/32
  latest handshake: 1 minute, 38 seconds ago
  transfer: 405.06 MiB received, 166.67 MiB sent

```

