### PR TITLE
add DS418play to compatability list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,7 @@ DS918+    apollolake 6.2         Yes
 RS214     armada370  *N/A*       No (Kernel version too old)
 RS816     armada38x  6.2         Yes
 DS216+II  braswell   6.2         Yes
+DS418play apollolake 6.2         Yes
 ========= ========== =========== ===========================
 
 The minimum required kernel version is 3.10. If you have a kernel version lower


### PR DESCRIPTION
Can confirm traffic is flowing after following the latest fixes in #10 

```
$ uname -a
Linux Diskstation 4.4.59+ #24922 SMP PREEMPT Fri May 10 02:59:42 CST 2019 x86_64 GNU/Linux synology_apollolake_418play
```

```
$ sudo wg
interface: wg0
  public key: <redacted>
  private key: (hidden)
  listening port: 993

peer: <redacted>
  endpoint: <redacted>
  allowed ips: <redacted>
  latest handshake: 53 seconds ago
  transfer: 23.11 MiB received, 383.24 MiB sent

peer: <redacted>
  endpoint: <redacted>
  allowed ips: <redacted>
  latest handshake: 56 seconds ago
  transfer: 113.68 MiB received, 243.09 MiB sent
```