### PR TITLE
add DS916+ to tested and works list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,7 @@ RS214     armada370  *N/A*       No (Kernel version too old)
 RS816     armada38x  6.2         Yes
 DS216+II  braswell   6.2         Yes
 DS418play apollolake 6.2         Yes
+DS916+    braswell   6.2         Yes
 ========= ========== =========== ===========================
 
 The minimum required kernel version is 3.10. If you have a kernel version lower


### PR DESCRIPTION
Processor:
```
# cat /proc/cpuinfo
processor       : 0
vendor_id       : GenuineIntel
cpu family      : 6
model           : 76
model name      : Intel(R) Pentium(R) CPU  N3710  @ 1.60GHz
stepping        : 4
microcode       : 0x404
cpu MHz         : 1601.000
cache size      : 1024 KB
physical id     : 0
siblings        : 4
core id         : 0
cpu cores       : 4
apicid          : 0
initial apicid  : 0
fpu             : yes
fpu_exception   : yes
cpuid level     : 11
wp              : yes
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 cx16 xtpr pdcm sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes rdrand lahf_lm 3dnowprefetch ida arat epb invpcid_single tpr_shadow vnmi flexpriority ept vpid tsc_adjust smep erms
bogomips        : 3201.13
clflush size    : 64
cache_alignment : 64
address sizes   : 36 bits physical, 48 bits virtual
power management:
```

4 cores.

Kernel: 
```
# uname -ar
Linux cube 3.10.105 #24922 SMP Wed Jul 3 16:34:56 CST 2019 x86_64 GNU/Linux synology_braswell_916+```