### PR TITLE
DS218 working and added

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,7 @@ DS213j    armada370  *N/A*       No (Kernel version too old)
 DS214play armada370  *N/A*       No (Kernel version too old)
 DS214se   armada370  *N/A*       No (Kernel version too old)
 DS216se   armada370  *N/A*       No (Kernel version too old)
+DS218     rtd1296    6.2         Yes
 DS218+    apollolake 6.2         Yes
 DS218j    armada38x  6.2         Yes
 DS414slim armada370  *N/A*       No (Kernel version too old)


### PR DESCRIPTION
```
 uname -a
 Linux serafino 4.4.59+ #24922 SMP Thu Mar 12 13:01:18 CST 2020 aarch64 GNU/Linux synology_rtd1296_ds218
```

```
 cat /proc/cpuinfo 
processor	: 0
model name	: ARMv8 Processor rev 4 (v8l)
BogoMIPS	: 54.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd03
CPU revision	: 4

processor	: 1
model name	: ARMv8 Processor rev 4 (v8l)
BogoMIPS	: 54.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd03
CPU revision	: 4

processor	: 2
model name	: ARMv8 Processor rev 4 (v8l)
BogoMIPS	: 54.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd03
CPU revision	: 4

processor	: 3
model name	: ARMv8 Processor rev 4 (v8l)
BogoMIPS	: 54.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd03
CPU revision	: 4
```
```
ifconfig
wg0       Link encap:UNSPEC  HWaddr 00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00  
          inet addr:10.6.6.11  P-t-P:10.6.66.201  Mask:255.255.255.255
          UP POINTOPOINT RUNNING NOARP  MTU:1420  Metric:1
          RX packets:14 errors:0 dropped:0 overruns:0 frame:0
          TX packets:70 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1 
          RX bytes:1432 (1.3 KiB)  TX bytes:3784 (3.6 KiB)
```

ping/ssh/everything is working properly
