### PR TITLE
Add bromolow (XPEnology) to working list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,7 @@ DS1511+   x64        6.2         Yes
 DS1618+   denverton  6.2         Yes
 DS1817+   avoton     6.2         Yes
 DS1815+   avoton     6.2         Yes
+DS3615xs  bromolow   6.2         Yes (XPEnology on HP54NL)
 DS213j    armada370  *N/A*       No (Kernel version too old)
 DS213j    armada370  *N/A*       No (Kernel version too old)
 DS214play armada370  *N/A*       No (Kernel version too old)


### PR DESCRIPTION
I have built the package for bromolow and installed the .spk. Works fine for now by using following command `docker run --rm --env PACKAGE_ARCH=bromolow --env DSM_VER=6.2 -v $(pwd)/artifacts:/result_spk synobuild`