### PR TITLE
Exclude Geminilake platform from memneq patch

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -64,7 +64,7 @@ set +e
 # built in memneq support. Unless HAS_MEMNEQ is defined we set it for models
 # that support it here.
 if [ -z ${HAS_MEMNEQ+x} ]; then
-    if [[ "$PACKAGE_ARCH" =~ ^apollolake|denverton|rtd1296$ ]]; then
+    if [[ "$PACKAGE_ARCH" =~ ^geminilake|apollolake|denverton|rtd1296$ ]]; then
         export HAS_MEMNEQ=1
     fi
 fi


### PR DESCRIPTION
NAS with Geminilake has built in memneq support so the patch should not be applied.