### PR TITLE
Apply memneq patch only for platforms that require it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-HAS_MEMNEQ ?= 0
+HAS_MEMNEQ ?= 1
 
 LIBMNL_TAR := libmnl-$(LIBMNL_VERSION).tar.bz2
 LIBMNL_DIR := libmnl-$(LIBMNL_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-HAS_MEMNEQ ?= 1
+APPLY_MEMNEQ_PATCH ?= 0
 
 LIBMNL_TAR := libmnl-$(LIBMNL_VERSION).tar.bz2
 LIBMNL_DIR := libmnl-$(LIBMNL_VERSION)
@@ -41,10 +41,10 @@ $(WIREGUARD_TOOLS_TAR):
 	wget https://git.zx2c4.com/wireguard-tools/snapshot/$(WIREGUARD_TOOLS_TAR)
 
 # Unpack WireGuard source tarball and patch the compatibility layer to always
-# use memneq implementation as it doesn't appear to be included on the D218j.
+# use memneq implementation if required.
 $(WIREGUARD_DIR)/src/Makefile: $(WIREGUARD_TAR)
 	tar -xf $(WIREGUARD_TAR)
-ifeq ($(HAS_MEMNEQ), 0)
+ifeq ($(APPLY_MEMNEQ_PATCH), 1)
 	patch $(WIREGUARD_DIR)/src/compat/Kbuild.include $(ROOT_DIR)/memneq.patch
 endif
 

--- a/README.rst
+++ b/README.rst
@@ -24,11 +24,6 @@ FAQ/Known issues
   `being too old <https://lists.zx2c4.com/pipermail/wireguard/2018-April/002687.html>`_.
   You'll get the error message
   ``Error: argument "suppress_prefixlength" is wrong: Failed to parse rule type``.
-* The error ``error: redefinition of 'crypto_memneq'`` means that you architecture
-  does not need the memneq workaround in wireguard. To work around the issue you
-  can pass ``--env HAS_MEMNEQ=1`` as an additional argument to you docker build.
-  If it works, please create an issue or send a PR to fix it properly for your
-  architecture.
 * Everything appears to be OK when running ``wg show`` but no traffic is flowing
   through the tunnel. Apparently there is some kind of race when setting up the
   interface. The simplest known workaround is to append

--- a/build.sh
+++ b/build.sh
@@ -76,8 +76,8 @@ set +e
 # built in memneq support. Unless HAS_MEMNEQ is defined we set it for models
 # that support it here.
 if [ -z ${HAS_MEMNEQ+x} ]; then
-    if [[ "$PACKAGE_ARCH" =~ ^geminilake|apollolake|denverton|broadwellnk|kvmx64|rtd1296$ ]]; then
-        export HAS_MEMNEQ=1
+    if [[ "$PACKAGE_ARCH" =~ ^bromolow|6281|x64|cedarview|qoriq|armadaxp|armada370|armada375|evansport|comcerto2k|avoton|alpine|alpine4k|braswell|monaco|armada38x|hi3535|broadwell|dockerx64|grantley$ ]]; then
+        export HAS_MEMNEQ=0
     fi
 fi
 


### PR DESCRIPTION
I suggest applying memneq patch by default only for platforms that require it. `crypto_memneq` is included in the kernel from 3.13. All newly Synology NAS have a 4.4.x kernel, so there will be no need to change the code for new devices. The list of platforms was prepared on the basis of data from the [platforms](https://github.com/SynologyOpenSource/pkgscripts-ng/blob/master/include/platforms) file of the pkgscripts-ng. The only exception is kvmx64 (Virtual DSM), which uses linux-4.4.x in its latest version.