### PR TITLE
Fix detection of crypto_memneq function definitions in tool chain

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -76,11 +76,14 @@ set +e
 if [ -z ${APPLY_MEMNEQ_PATCH+x} ]; then
   source "/pkgscripts-ng/include/platform.$PACKAGE_ARCH"
   if [ ! -z ${ToolChainSysRoot64} ]; then
-    ToolChainSysRoot=ToolChainSysRoot64
+    ToolChainSysRoot="$ToolChainSysRoot64"
   elif [ ! -z ${ToolChainSysRoot32} ]; then
-    ToolChainSysRoot=ToolChainSysRoot32
+    ToolChainSysRoot="$ToolChainSysRoot32"
   fi
-  if ! grep -q "int crypto_memneq" "$build_env/$ToolChainSysRoot64/usr/lib/modules/DSM-$DSM_VER/build/include/crypto/algapi.h"; then
+  if ! grep -q "int crypto_memneq" "$build_env/$ToolChainSysRoot/usr/lib/modules/DSM-$DSM_VER/build/include/crypto/algapi.h"; then
+    export APPLY_MEMNEQ_PATCH=1
+  elif grep -q "#if defined(CONFIG_SYNO_BACKPORT_ARM_CRYPTO)" "$build_env/$ToolChainSysRoot/usr/lib/modules/DSM-$DSM_VER/build/include/crypto/algapi.h" && \
+  ! grep -qx "CONFIG_SYNO_BACKPORT_ARM_CRYPTO=y" "$build_env/$ToolChainSysRoot/usr/lib/modules/DSM-$DSM_VER/build/.config"; then
     export APPLY_MEMNEQ_PATCH=1
   fi
 fi


### PR DESCRIPTION
With reference to #67.

I must have been very tired during the last changes and did not notice such an obvious error in the code.
Additionally, for some platforms the `crypto_memneq` function is only declared if `CONFIG_SYNO_BACKPORT_ARM_CRYPTO` is defined.