### PR TITLE
Fixes issue with building Wireguard package withdocker on DSM 7.0 #88

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -114,6 +114,9 @@ fi
 # Disable quit if errors to allow printing of logfiles
 set +e
 
+# bind mount /dev into build env chroot
+mount -o bind /dev $build_env/dev
+
 # Build packages
 #   -p              package arch
 #   -v              DSM version


### PR DESCRIPTION
The build env extracts an own set of "/dev" inside the chroot and somehow the container is not able to write to /dev/null or read from other devices. This patch adds a bind mount to mount the container "/dev" directory into the chroot environment. Then the build works as expected.