### PR TITLE
fix #130: wireguard patch added for armada38x / DSM 7.0 build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ $(WIREGUARD_DIR)/src/Makefile: $(WIREGUARD_TAR)
 	tar -xf $(WIREGUARD_TAR)
 	patch $(WIREGUARD_DIR)/src/netlink.c $(ROOT_DIR)/patch/netlink.patch
 	patch $(WIREGUARD_DIR)/src/peerlookup.c $(ROOT_DIR)/patch/peerlookup.patch
+	patch $(WIREGUARD_DIR)/src/compat/siphash/siphash.c $(ROOT_DIR)/patch/siphash.patch
 ifeq ($(APPLY_MEMNEQ_PATCH), 1)
 	patch $(WIREGUARD_DIR)/src/compat/Kbuild.include $(ROOT_DIR)/patch/memneq.patch
 endif

--- a/patch/siphash.patch
+++ b/patch/siphash.patch
@@ -1,0 +1,84 @@
+--- a/src/compat/siphash/siphash.c
++++ b/src/compat/siphash/siphash.c
+@@ -77,11 +77,11 @@ u64 __siphash_aligned(const void *data, size_t len, const siphash_key_t *key)
+ 						  bytemask_from_count(left)));
+ #else
+ 	switch (left) {
+-	case 7: b |= ((u64)end[6]) << 48; fallthrough;
+-	case 6: b |= ((u64)end[5]) << 40; fallthrough;
+-	case 5: b |= ((u64)end[4]) << 32; fallthrough;
++	case 7: b |= ((u64)end[6]) << 48;
++	case 6: b |= ((u64)end[5]) << 40;
++	case 5: b |= ((u64)end[4]) << 32;
+ 	case 4: b |= le32_to_cpup(data); break;
+-	case 3: b |= ((u64)end[2]) << 16; fallthrough;
++	case 3: b |= ((u64)end[2]) << 16;
+ 	case 2: b |= le16_to_cpup(data); break;
+ 	case 1: b |= end[0];
+ 	}
+@@ -109,11 +109,11 @@ u64 __siphash_unaligned(const void *data, size_t len, const siphash_key_t *key)
+ 						  bytemask_from_count(left)));
+ #else
+ 	switch (left) {
+-	case 7: b |= ((u64)end[6]) << 48; fallthrough;
+-	case 6: b |= ((u64)end[5]) << 40; fallthrough;
+-	case 5: b |= ((u64)end[4]) << 32; fallthrough;
++	case 7: b |= ((u64)end[6]) << 48;
++	case 6: b |= ((u64)end[5]) << 40;
++	case 5: b |= ((u64)end[4]) << 32;
+ 	case 4: b |= get_unaligned_le32(end); break;
+-	case 3: b |= ((u64)end[2]) << 16; fallthrough;
++	case 3: b |= ((u64)end[2]) << 16;
+ 	case 2: b |= get_unaligned_le16(end); break;
+ 	case 1: b |= end[0];
+ 	}
+@@ -269,11 +269,11 @@ u32 __hsiphash_aligned(const void *data, size_t len, const hsiphash_key_t *key)
+ 						  bytemask_from_count(left)));
+ #else
+ 	switch (left) {
+-	case 7: b |= ((u64)end[6]) << 48; fallthrough;
+-	case 6: b |= ((u64)end[5]) << 40; fallthrough;
+-	case 5: b |= ((u64)end[4]) << 32; fallthrough;
++	case 7: b |= ((u64)end[6]) << 48;
++	case 6: b |= ((u64)end[5]) << 40;
++	case 5: b |= ((u64)end[4]) << 32;
+ 	case 4: b |= le32_to_cpup(data); break;
+-	case 3: b |= ((u64)end[2]) << 16; fallthrough;
++	case 3: b |= ((u64)end[2]) << 16;
+ 	case 2: b |= le16_to_cpup(data); break;
+ 	case 1: b |= end[0];
+ 	}
+@@ -301,11 +301,11 @@ u32 __hsiphash_unaligned(const void *data, size_t len,
+ 						  bytemask_from_count(left)));
+ #else
+ 	switch (left) {
+-	case 7: b |= ((u64)end[6]) << 48; fallthrough;
+-	case 6: b |= ((u64)end[5]) << 40; fallthrough;
+-	case 5: b |= ((u64)end[4]) << 32; fallthrough;
++	case 7: b |= ((u64)end[6]) << 48;
++	case 6: b |= ((u64)end[5]) << 40;
++	case 5: b |= ((u64)end[4]) << 32;
+ 	case 4: b |= get_unaligned_le32(end); break;
+-	case 3: b |= ((u64)end[2]) << 16; fallthrough;
++	case 3: b |= ((u64)end[2]) << 16;
+ 	case 2: b |= get_unaligned_le16(end); break;
+ 	case 1: b |= end[0];
+ 	}
+@@ -426,7 +426,7 @@ u32 __hsiphash_aligned(const void *data, size_t len, const hsiphash_key_t *key)
+ 		v0 ^= m;
+ 	}
+ 	switch (left) {
+-	case 3: b |= ((u32)end[2]) << 16; fallthrough;
++	case 3: b |= ((u32)end[2]) << 16;
+ 	case 2: b |= le16_to_cpup(data); break;
+ 	case 1: b |= end[0];
+ 	}
+@@ -448,7 +448,7 @@ u32 __hsiphash_unaligned(const void *data, size_t len,
+ 		v0 ^= m;
+ 	}
+ 	switch (left) {
+-	case 3: b |= ((u32)end[2]) << 16; fallthrough;
++	case 3: b |= ((u32)end[2]) << 16;
+ 	case 2: b |= get_unaligned_le16(end); break;
+ 	case 1: b |= end[0];
+ 	}


### PR DESCRIPTION
A build issue was introduced on the wiregard-linux-compat codebase.
The fix has been requested for a merge on the project repository
https://github.com/WireGuard/wireguard-linux-compat/pull/5

Waiting it to be merged, a patch was added to this project to locally
fix the problem