### PR TITLE
Fix build for DSM_VER=7.1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,7 +36,7 @@ if [[ ! -d /pkgscripts-ng ]] || [ -z "$(ls -A /pkgscripts-ng)" ]; then
     clone_args=""
     # If the DSM version is 7.0, use the DSM7.0 branch of pkgscripts-ng
     if [[ "$DSM_VER" =~ ^7\.[0-9]+$ ]]; then
-        clone_args="-b DSM7.0"
+        clone_args="-b DSM${DSM_VER}"
         export PRODUCT="DSM"
     fi
     git clone ${clone_args} https://github.com/SynologyOpenSource/pkgscripts-ng


### PR DESCRIPTION
This appears to help build the wireguard package for DSM version 7.1.