### PR TITLE
Fix compiler issue with Linux kernel >= 5.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 artifacts/
+toolkit_tarballs/

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ $(WIREGUARD_DIR)/src/Makefile: $(WIREGUARD_TAR)
 	tar -xf $(WIREGUARD_TAR)
 	patch $(WIREGUARD_DIR)/src/netlink.c $(ROOT_DIR)/patch/netlink.patch
 	patch $(WIREGUARD_DIR)/src/peerlookup.c $(ROOT_DIR)/patch/peerlookup.patch
+	patch $(WIREGUARD_DIR)/src/compat/compat.h $(ROOT_DIR)/patch/wireguard-linux-compat.patch
 ifeq ($(APPLY_MEMNEQ_PATCH), 1)
 	patch $(WIREGUARD_DIR)/src/compat/Kbuild.include $(ROOT_DIR)/patch/memneq.patch
 endif

--- a/build.sh
+++ b/build.sh
@@ -36,7 +36,7 @@ if [[ ! -d /pkgscripts-ng ]] || [ -z "$(ls -A /pkgscripts-ng)" ]; then
     clone_args=""
     # If the DSM version is 7.0, use the DSM7.0 branch of pkgscripts-ng
     if [[ "$DSM_VER" =~ ^7\.[0-9]+$ ]]; then
-        clone_args="-b DSM7.0"
+        clone_args="-b DSM$DSM_VER"
         export PRODUCT="DSM"
     fi
     git clone ${clone_args} https://github.com/SynologyOpenSource/pkgscripts-ng

--- a/patch/wireguard-linux-compat.patch
+++ b/patch/wireguard-linux-compat.patch
@@ -1,0 +1,13 @@
+--- src/compat/compat.h	2022-06-27 12:54:37.000000000 +0200
++++ src/compat/compat.h	2024-03-31 01:44:27.000000000 +0100
+@@ -37,10 +37,6 @@
+ #error "WireGuard requires Linux >= 3.10"
+ #endif
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+-#error "WireGuard has been merged into Linux >= 5.6 and therefore this compatibility module is no longer required."
+-#endif
+-
+ #if defined(ISRHEL7)
+ #include <linux/skbuff.h>
+ #define headers_end headers_start


### PR DESCRIPTION
This PR fixes the following issues:
* Not checking out the correct branch in `pkgscripts-ng` for DSM > 7.0 (also see #167 )
* Throwing an error if Linux kernel used by the Docker image >= 5.6.0 (see issue #176 )

With those changes I managed to get a working version for the DS223J (rtd1619b)