### PR TITLE
Fix DSM 7.x build support for newer platforms and kernel versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ $(WIREGUARD_TOOLS_TAR):
 # and patch the spinlock implementation.
 $(WIREGUARD_DIR)/src/Makefile: $(WIREGUARD_TAR)
 	tar -xf $(WIREGUARD_TAR)
+	patch $(WIREGUARD_DIR)/src/compat/compat.h $(ROOT_DIR)/patch/compat.patch
 	patch $(WIREGUARD_DIR)/src/netlink.c $(ROOT_DIR)/patch/netlink.patch
 	patch $(WIREGUARD_DIR)/src/peerlookup.c $(ROOT_DIR)/patch/peerlookup.patch
 ifeq ($(APPLY_MEMNEQ_PATCH), 1)

--- a/build.sh
+++ b/build.sh
@@ -34,9 +34,9 @@ echo
 # Fetch Synology toolchain
 if [[ ! -d /pkgscripts-ng ]] || [ -z "$(ls -A /pkgscripts-ng)" ]; then
     clone_args=""
-    # If the DSM version is 7.0, use the DSM7.0 branch of pkgscripts-ng
+    # If the DSM version is 7.x, use the appropriate DSM7.x branch of pkgscripts-ng
     if [[ "$DSM_VER" =~ ^7\.[0-9]+$ ]]; then
-        clone_args="-b DSM7.0"
+        clone_args="-b DSM${DSM_VER}"
         export PRODUCT="DSM"
     fi
     git clone ${clone_args} https://github.com/SynologyOpenSource/pkgscripts-ng

--- a/patch/compat.patch
+++ b/patch/compat.patch
@@ -1,0 +1,13 @@
+--- compat.h	2022-06-27 00:00:00.000000000 +0000
++++ compat.h	2026-02-09 00:00:00.000000000 +0000
+@@ -36,10 +36,6 @@
+ #error "WireGuard requires Linux >= 3.10"
+ #endif
+
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+-#error "WireGuard has been merged into Linux >= 5.6 and therefore this compatibility module is no longer required."
+-#endif
+-
+ #if defined(ISRHEL7)
+ #include <linux/skbuff.h>
+ #define headers_end headers_start


### PR DESCRIPTION
## Summary
This PR fixes build failures for DSM 7.2+ systems, specifically addressing the `PlatformNotAvailableError` for newer platforms like v1000nk.

## Changes

### 1. Dynamic DSM Branch Selection (build.sh)
- Changed from hardcoded `-b DSM7.0` to `-b DSM${DSM_VER}` when cloning pkgscripts-ng
- This allows the build system to use the correct branch (DSM7.1, DSM7.2, DSM7.3, etc.) based on the target DSM version
- **Why needed**: Newer platforms like v1000nk were introduced in DSM 7.3 and only exist in the DSM7.3 branch of pkgscripts-ng

### 2. Kernel Version Check Bypass (patch/compat.patch + Makefile)
- Added a new patch to remove the kernel >= 5.6 version check from wireguard-linux-compat
- **Why needed**: While DSM 7.3 uses Linux kernel 5.10.55, Synology disabled WireGuard support in their kernel build. The compatibility module is still required despite the newer kernel version.

## Testing
Successfully built and tested with:
- Platform: v1000nk
- DSM Version: 7.3
- Kernel: 5.10.55

Build output confirms:
- Toolchain downloads correctly
- All patches apply successfully  
- Kernel module (wireguard.ko) compiles without errors
- SPK package created: `WireGuard-v1000nk-1.0.20220627.spk`

## Related Issues
Fixes builds for DSM 7.2+ with newer platforms that don't exist in the DSM7.0 branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)